### PR TITLE
Add mp metrics

### DIFF
--- a/scoreboardService/src/main/java/application/rest/Scoreboard.java
+++ b/scoreboardService/src/main/java/application/rest/Scoreboard.java
@@ -2,6 +2,8 @@ package application.rest;
 
 import javax.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.metrics.annotation.Timed;
+
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -56,6 +58,7 @@ public class Scoreboard {
       )
     )
   })
+  @Timed
   public Response scores() {
     return Response.ok().entity(persistence.getTopTenScores()).build();
   }
@@ -85,6 +88,7 @@ public class Scoreboard {
       )
     )
   })
+  @Timed
   public synchronized Response addScore(
     @RequestBody(
         description = "New score",
@@ -106,6 +110,7 @@ public class Scoreboard {
   @Path("/reset")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.TEXT_PLAIN)
+  @Timed
   public synchronized Response reset(JSONObject request) {
     if (!deployment.equals("production")) {
       String state = (String) request.get("state");

--- a/scoreboardService/src/main/liberty/config/server.xml
+++ b/scoreboardService/src/main/liberty/config/server.xml
@@ -4,6 +4,7 @@
       <feature>mpOpenAPI-1.0</feature>
       <feature>mpHealth-1.0</feature>
       <feature>mpConfig-1.2</feature>
+      <feature>mpMetrics-1.1</feature>
       <feature>mpJwt-1.0</feature>
       <feature>ssl-1.0</feature>
       <feature>appSecurity-2.0</feature>
@@ -52,11 +53,11 @@
   </library>
     
   <!-- The MP JWT configuration that injects the caller's JWT into a ResourceScoped bean for inspection. -->
-  <mpJwt id="jwtUserConsumer" 
-    keyName="default" 
-    audiences="scoreboard" 
-    issuer="${jwt.issuer}"/>
-  
+  <mpJwt id="jwtUserConsumer" keyName="default"
+  	issuer="${jwt.issuer}">
+  	<audiences>scoreboard</audiences>
+  </mpJwt>
+
   <!-- This is the keystore that will be used by SSL and by JWT.
        The keystore is built using the maven keytool plugin -->
   <keyStore id="defaultKeyStore" 
@@ -64,4 +65,7 @@
     type="JKS" 
     password="secret" />
 
+  <administrator-role>
+    <group-access-id>group:http://openliberty.io/player</group-access-id>
+  </administrator-role>
 </server>


### PR DESCRIPTION
This will create an extra endpoint at `https://localhost:32443/metrics` that will let all players see the metrics such as this:

```
$ curl -X GET -k -H 'Authorization: Bearer <redacted>' -i https://localhost:32443/metrics
# TYPE base:classloader_total_loaded_class_count counter
# HELP base:classloader_total_loaded_class_count Displays the total number of classes that have been loaded since the Java virtual machine has started execution.
base:classloader_total_loaded_class_count 12751
# TYPE base:gc_global_count counter
# HELP base:gc_global_count Displays the total number of collections that have occurred. This attribute lists -1 if the collection count is undefined for this collector.
base:gc_global_count 8
...
# TYPE application:application_rest_scoreboard_add_score_rate_per_second gauge
application:application_rest_scoreboard_add_score_rate_per_second 0.0036656824484023573
# TYPE application:application_rest_scoreboard_add_score_one_min_rate_per_second gauge
application:application_rest_scoreboard_add_score_one_min_rate_per_second 1.0299928799851114E-5
# TYPE application:application_rest_scoreboard_add_score_five_min_rate_per_second gauge
application:application_rest_scoreboard_add_score_five_min_rate_per_second 0.0013237910317939344
# TYPE application:application_rest_scoreboard_add_score_fifteen_min_rate_per_second gauge
application:application_rest_scoreboard_add_score_fifteen_min_rate_per_second 0.0012964424695556082
# TYPE application:application_rest_scoreboard_add_score_mean_seconds gauge
application:application_rest_scoreboard_add_score_mean_seconds 0.01635042252180061
# TYPE application:application_rest_scoreboard_add_score_max_seconds gauge
application:application_rest_scoreboard_add_score_max_seconds 0.0337384
# TYPE application:application_rest_scoreboard_add_score_min_seconds gauge
application:application_rest_scoreboard_add_score_min_seconds 6.956E-4
# TYPE application:application_rest_scoreboard_add_score_stddev_seconds gauge
application:application_rest_scoreboard_add_score_stddev_seconds 0.016498657564610452
# TYPE application:application_rest_scoreboard_add_score_seconds summary
application:application_rest_scoreboard_add_score_seconds_count 2
application:application_rest_scoreboard_add_score_seconds{quantile="0.5"} 6.956E-4
application:application_rest_scoreboard_add_score_seconds{quantile="0.75"} 0.0337384
application:application_rest_scoreboard_add_score_seconds{quantile="0.95"} 0.0337384
application:application_rest_scoreboard_add_score_seconds{quantile="0.98"} 0.0337384
application:application_rest_scoreboard_add_score_seconds{quantile="0.99"} 0.0337384
application:application_rest_scoreboard_add_score_seconds{quantile="0.999"} 0.0337384
```